### PR TITLE
[FIX] add required exception and context parameters to OdooRPC reques…

### DIFF
--- a/src/OdooLocust/OdooLocustUser.py
+++ b/src/OdooLocust/OdooLocustUser.py
@@ -45,11 +45,11 @@ def send(self, service_name, method, *args):
         res = odoolib.json_rpc(self.url, "call", {"service": service_name, "method": method, "args": args})
     except Exception as e:
         total_time = int((time.time() - start_time) * 1000)
-        events.request.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=0, exception=e)
+        events.request.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=0, exception=e, context={})
         raise e
     else:
         total_time = int((time.time() - start_time) * 1000)
-        events.request.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=sys.getsizeof(res))
+        events.request.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=sys.getsizeof(res), exception=None, context={})
         return res
 
 


### PR DESCRIPTION
…t events

I triggered and discovered this issues using locust's `run_single_user()` method used for debugging (see: [running in debugger (locust doc website)](https://docs.locust.io/en/stable/running-in-debugger.html))

My `OdooLocustUser` locustfiles triggered this exception :

```
[2024-06-03 16:23:59,295] dmuyshond-T590/ERROR/root: Uncaught exception in event handler: Traceback (most recent call last):
  File "/home/dmuyshond/src/imio/locust-testcases/iavision-locust-testcases/venv/lib/python3.11/site-packages/locust/event.py", line 47, in fire
    handler(**kwargs)
TypeError: PrintListener.on_request() missing 2 required positional arguments: 'exception' and 'context'
```

I fixed it explicitly specifying (apparently) required and missing arguments `context` and `exception` in `OdooLocustUser.py`, inside the `send()` method, at the `events.request.fire()` methods.

I hope it's clear. This is my first ever pull request on an open source project I'm not working on at work, so please let me know if something can be improved! 😉 